### PR TITLE
Remove dependency on "jq"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Open VMDK is an assistant tool for making OVA from vSphere virtual machine.
 
 ## Getting Started
 
-### Prerequisites
-
-Before you use open-vmdk, you need to have [jq](https://stedolan.github.io/jq/) installed in your machine. Please refer to https://stedolan.github.io/jq/download/ for jq installation.
-
 ### Installation
 Firstly, you need to download and extract [open-vmdk-master.zip](https://github.com/vmware/open-vmdk/archive/master.zip) and extract it:
 ```

--- a/ova/mkova.sh
+++ b/ova/mkova.sh
@@ -44,7 +44,7 @@ cp "$vmdk" $TMPDIR/"${name}"-disk1.vmdk
 
 VMDK_FILE_SIZE=$(du -b $TMPDIR/"${name}-disk1.vmdk" | cut -f1)
 echo "vmdk file size is $VMDK_FILE_SIZE"
-VMDK_CAPACITY=$(vmdk-convert -i "$vmdk" | jq .capacity)
+VMDK_CAPACITY=$(vmdk-convert -i "$vmdk" | cut -d ',' -f 1 | awk '{print $NF}')
 echo "vmdk capacity is $VMDK_CAPACITY"
 sed ${ovftempl} \
 	-e "s/@@NAME@@/${name}/g" \


### PR DESCRIPTION
Test Steps:
1. Uninstall jq from Ubuntu host.
2. Run vmdk-convert to convert the flat disk
3. Run mkova.sh to create the OVA package. No jq dependency error was reported.
4. Deploy the OVA package on vSphere server. The deployment was successful and the new VM could be powered on and booted.