### PR TITLE
Add CLI support in the open-vmdk tool to support adding arbitrary number of disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,36 @@ $ cd $TESTSVM_PATH
 $ vmdk-converter testvm-flat.vmdk
 ```
 After converting, a new vmdk file `dst.vmdk` will be created under `$TESTSVM_PATH` folder.
+Or, you can specify the new vmdk file name by running
+```
+$ vmdk-converter testvm-flat.vmdk disk1.vmdk
+```
+After converting, a new vmdk file `disk1.vmdk` will be created under `$TESTSVM_PATH` folder.
 
 3. Run `mkova.sh` to create OVA with specific hardware version.
 ```
-$ mkova.sh ova_name dst.vmdk path_to_template_ovf
+$ mkova.sh ova_name path_to_ovf_template disk1.vmdk 
 ```
 Where,
 * _ova_name_ is your OVA name without .ova suffix.
 * _dst.vmdk_ is the new vmdk file converted in step 2.
-* _path_to_template_ovf_ is the path to .ovf template file. There are 4 .ovf templates files can be used.
+* _path_to_ovf_template_ is the path to .ovf template file. There are 8 .ovf templates files can be used.
     * `ova/template.ovf` is the template for BIOS VM with hardware version 7.
     * `ova/template-hw10.ovf` is the template for BIOS VM with hardware version 10.
     * `ova/template-hw11-bios.ovf` is the template for BIOS VM with hardware version 11.
     * `ova/template-hw11-uefi.ovf` is the template for UEFI VM with hardware version 11.
+    * `ova/template-hw13-bios.ovf` is the template for BIOS VM with hardware version 13.
+    * `ova/template-hw13-uefi.ovf` is the template for UEFI VM with hardware version 13.
+    * `ova/template-hw14-bios.ovf` is the template for BIOS VM with hardware version 14.
+    * `ova/template-hw14-uefi.ovf` is the template for UEFI VM with hardware version 14.
+
+If you want to add more than 1 disk into the OVA, firstly convert all flat vmdk files, and add new converted vmdk files by following path_to_ovf_template.
+For example, below command creates an OVA with 3 disks
+```
+$ mkova.sh ova_name path_to_ovf_template disk1.vmdk disk2.vmdk disk3.vmdk
+```
+Here mutiple disks are only supported to be attached to one SCSI controller, and at most 15 disks can be added in one OVA.
+
+By default, the OVA will be created with 2 cpus and 1024 MB memory. You can also use environment variable NUM_CPUS and MEM_SIZE to change the default number of cpu and memory size.
 
 4. After `mkova.sh` completes, you would be able to see the final OVA under `$TESTSVM_PATH` folder.

--- a/ova/mkova.sh
+++ b/ova/mkova.sh
@@ -20,54 +20,122 @@ TMPDIR=$(mktemp -p . -d XXXXXXXX)
 [ ! -n "$NUM_CPUS" ] && NUM_CPUS=2
 [ ! -n "$MEM_SIZE" ] && MEM_SIZE=1024
 
-if [ "$#" -ne 3 ] ; then
-	echo "$#"
-	echo usage "$0 name disk.vmdk template.ovf"
-	exit 1
+if [ "$#" -lt 3 ] ; then
+    echo "$#"
+    echo "usage: $0 ova_name path_to_ovf_template disk1.vmdk [disk2.vmdk disk3.vmdk ...]"
+    exit 1
 fi
 
 name=$1
-vmdk=$2
-ovftempl=$3
+ovftempl=$2
+shift
+shift
+vmdks=$@
+vmdks_num=$#
 
-if [ ! -f "$vmdk" ] ; then
-	echo "$vmdk not found"
-	exit 2
-fi
+echo "Starting to create ${name}.ova of ${vmdks_num} disks with template ${ovftempl}"
+
+for vmdk in $vmdks; do
+    if [ ! -f "$vmdk" ] ; then
+        echo "$vmdk not found"
+        exit 2
+    fi
+done
 
 if [ ! -f "$ovftempl" ] ; then
-	echo "$ovftempl not found"
-	exit 2
+    echo "$ovftempl not found"
+    exit 2
 fi
 
-cp "$vmdk" $TMPDIR/"${name}"-disk1.vmdk
-
-VMDK_FILE_SIZE=$(du -b $TMPDIR/"${name}-disk1.vmdk" | cut -f1)
-echo "vmdk file size is $VMDK_FILE_SIZE"
-VMDK_CAPACITY=$(vmdk-convert -i "$vmdk" | cut -d ',' -f 1 | awk '{print $NF}')
-echo "vmdk capacity is $VMDK_CAPACITY"
-sed ${ovftempl} \
-	-e "s/@@NAME@@/${name}/g" \
-	-e "s/@@VMDK_FILE_SIZE@@/$VMDK_FILE_SIZE/g" \
-	-e "s/@@VMDK_CAPACITY@@/$VMDK_CAPACITY/g" \
-	-e "s/@@NUM_CPUS@@/$NUM_CPUS/g" \
-	-e "s/@@MEM_SIZE@@/$MEM_SIZE/g" \
-	> $TMPDIR/${name}.ovf
-
-hw_version=$(grep "<vssd:VirtualSystemType>" $TMPDIR/${name}.ovf | sed 's#</*vssd:VirtualSystemType>##g' | cut -d '-' -f 2)
+hw_version=$(grep "<vssd:VirtualSystemType>" $ovftempl | sed 's#</*vssd:VirtualSystemType>##g' | cut -d '-' -f 2)
 if [ $hw_version -le 12 ]; then
-    echo "SHA1(${name}-disk1.vmdk)= $(sha1sum $TMPDIR/${name}-disk1.vmdk | cut -d' ' -f1)" > $TMPDIR/${name}.mf
-    echo "SHA1(${name}.ovf)= $(sha1sum $TMPDIR/${name}.ovf | cut -d' ' -f1)" >> $TMPDIR/${name}.mf
+    sha_alg=1
 elif [ $hw_version -eq 13 ] || [ $hw_version -eq 14 ]; then
-    echo "SHA256(${name}-disk1.vmdk)= $(sha256sum $TMPDIR/${name}-disk1.vmdk | cut -d' ' -f1)" > $TMPDIR/${name}.mf
-    echo "SHA256(${name}.ovf)= $(sha256sum $TMPDIR/${name}.ovf | cut -d' ' -f1)" >> $TMPDIR/${name}.mf
+    sha_alg=256
 elif [ $hw_version -gt 14 ]; then
-    echo "SHA512(${name}-disk1.vmdk)= $(sha512sum $TMPDIR/${name}-disk1.vmdk | cut -d' ' -f1)" > $TMPDIR/${name}.mf
-    echo "SHA512(${name}.ovf)= $(sha512sum $TMPDIR/${name}.ovf | cut -d' ' -f1)" >> $TMPDIR/${name}.mf
+    sha_alg=512
 fi
+
+# If there are more than one vmdk, we need to know what is the next available instance id for other disks
+max_id=0
+for id in `grep InstanceID $ovftempl | sed 's/[^0-9]*//g'`; do
+    if [ $id -gt $max_id ]; then
+        max_id=$id
+    fi
+done
+next_id=$((max_id+1))
+
+# Get vmdk parent id
+disk_parent_id=`sed -n '/Hard Disk 1/,+3p' $ovftempl | grep Parent | sed 's/[^0-9]*//g'`
+
+index=1
+for vmdk in $vmdks; do
+   vmdk_name="${name}-disk${index}.vmdk"
+
+   echo "Adding $vmdk as ${vmdk_name}"
+   cp "$vmdk" $TMPDIR/"${vmdk_name}"
+
+   vmdk_file_size=$(du -b $TMPDIR/"${vmdk_name}" | cut -f1)
+   echo "$vmdk file size is $vmdk_file_size"
+   vmdk_capacity=$(vmdk-convert -i "$vmdk" | cut -d ',' -f 1 | awk '{print $NF}')
+   echo "$vmdk capacity is $vmdk_capacity"
+
+   if [ $index -eq 1 ]; then
+      sed ${ovftempl} \
+          -e "s/@@NAME@@/${name}/g" \
+          -e "s/@@VMDK_FILE_SIZE@@/$vmdk_file_size/g" \
+          -e "s/@@VMDK_CAPACITY@@/$vmdk_capacity/g" \
+          -e "s/@@NUM_CPUS@@/$NUM_CPUS/g" \
+          -e "s/@@MEM_SIZE@@/$MEM_SIZE/g" \
+          > $TMPDIR/${name}.ovf
+   else
+       # Insert disk file information for Hard Disk 2, 3, 4, etc
+       last_index=$((index-1))
+       sed -i \
+           -e "/${name}-disk${last_index}.vmdk/a \
+              <File ovf:href=\"${vmdk_name}\" ovf:id=\"file${index}\" ovf:size=\"${vmdk_file_size}\"/>" \
+           -e "/ovf:fileRef=\"file${last_index}\"/a \
+              <Disk ovf:capacity=\"${vmdk_capacity}\" ovf:capacityAllocationUnits=\"byte\" ovf:diskId=\"vmdisk${index}\" ovf:fileRef=\"file${index}\" ovf:format=\"http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized\" ovf:populatedSize=\"0\"/>" \
+          $TMPDIR/"${name}".ovf
+
+       # Insert hardware item information for Hard Disk 2, 3, 4, etc
+       insert_after=`grep -n '</Item>' $TMPDIR/"${name}".ovf | tail -n 1 | cut -d: -f 1`
+
+       # There is no scsi0:7, so we need to skip it.
+       if [ $last_index -lt 7 ]; then
+           address_on_parent=$last_index
+       else
+           address_on_parent=$((last_index+1))
+       fi
+
+       sed -i -e "${insert_after}a \
+             <Item>\n\
+                <rasd:AddressOnParent>${address_on_parent}</rasd:AddressOnParent>\n\
+                <rasd:ElementName>Hard Disk $index</rasd:ElementName>\n\
+                <rasd:HostResource>ovf:/disk/vmdisk$index</rasd:HostResource>\n\
+                <rasd:InstanceID>${next_id}</rasd:InstanceID>\n\
+                <rasd:Parent>$disk_parent_id</rasd:Parent>\n\
+                <rasd:ResourceType>17</rasd:ResourceType>\n\
+                <vmw:Config ovf:required=\"false\" vmw:key=\"backing.writeThrough\" vmw:value=\"false\"/>\n\
+             </Item>" \
+          $TMPDIR/"${name}".ovf
+
+       next_id=$((next_id+1))
+   fi
+
+   index=$((index+1))
+
+   # Get the sha checksum of the vmdk file
+   echo "SHA${sha_alg}($vmdk_name)= $(sha${sha_alg}sum $TMPDIR/${vmdk_name} | cut -d' ' -f1)" >> $TMPDIR/${name}.mf
+done
+
+# Get the sha checksum of the ovf file
+echo "SHA${sha_alg}(${name}.ovf)= $(sha${sha_alg}sum $TMPDIR/${name}.ovf | cut -d' ' -f1)" >> $TMPDIR/${name}.mf
 
 pushd $TMPDIR 
 tar cf ../${name}.ova *.ovf *.mf *.vmdk
 popd
+
+echo "Completed to create ${name}.ova"
 
 rm -rf $TMPDIR


### PR DESCRIPTION
Test Commit 6f92ff4580d8bf9101b8ebf29c1ad6d0674ddb09 Add CLI support in the open-vmdk tool to support adding arbitrary number of disks

Case 1. Create OVA with 3 disks with OVF templates for HW11, HW13, and HW14 respectively
Step 1. Run vmdk-convert to convert 3 flat vmdk files.
Step 2. Run mkova.sh to create an OVA with 3 disks
Step 3. Deploy new OVAs on ESXi 6.0, 6.5U2, and 6.7 servers.
Step 4. Check the VM's disk number, which should be as expected 2 disks.
Step 5. Power on the VM and check the guest booting up successfully without errors. Check the file content on each disk, no data loss.

Test Result: Passed.

Case 2. Create OVA with 15 disks with OVF templates for HW11, HW13, and HW14 respectively
Step 1. Run vmdk-convert to convert 15 flat vmdk files.
Step 2. Run mkova.sh to create an OVA with 15 disks
Step 3. Deploy new OVAs on ESXi 6.0, 6.5U2, and 6.7 servers.
Step 4. Check the VM's disk number, which should be as expected 15 disks.
Step 5. Power on the VM and check the guest booting up successfully without errors. Check the file content on each disk, no data loss.

Test Result: Passed.

Santiy test creating OVA with 1 disk and passed.