### PR TITLE
vmdk: fix build issues with gcc 10 or newer

### DIFF
--- a/vmdk/diskinfo.h
+++ b/vmdk/diskinfo.h
@@ -35,7 +35,7 @@ struct DiskInfo {
 	const DiskInfoVMT *vmt;
 };
 
-char *toolsVersion; /* toolsVersion in metadata */
+extern char *toolsVersion; /* toolsVersion in metadata */
 
 DiskInfo *Flat_Open(const char *fileName);
 DiskInfo *Flat_Create(const char *fileName, off_t capacity);

--- a/vmdk/mkdisk.c
+++ b/vmdk/mkdisk.c
@@ -24,6 +24,8 @@
 #include <string.h>
 #include <getopt.h>
 
+char *toolsVersion; /* toolsVersion in metadata */
+
 static int
 copyData(DiskInfo *dst,
          off_t dstOffset,


### PR DESCRIPTION
As gcc 10 or newer defaults to `-fno-common`, we need to define only once in a *.c file, instead of *.h that can be imported multiple times by *.c files.

Otherwise, build would fail like:
```
.../x86_64-pc-linux-gnu/bin/ld:
../build/vmdk/mkdisk.o:.../vmdk/diskinfo.h:38: multiple definition of `toolsVersion';
../build/vmdk/flat.o:.../vmdk/diskinfo.h:38: first defined here
```

Fixes https://github.com/vmware/open-vmdk/issues/12