### PR TITLE
fix gcc 10 warning - "'cp.pos' may be used uninitialized in this function"

### DIFF
--- a/vmdk/sparse.c
+++ b/vmdk/sparse.c
@@ -908,7 +908,7 @@ Sparse_Open(const char *fileName)
 	SparseExtentHeaderOnDisk onDisk;
 	uint32_t i;
 	uint32_t *gt;
-	CoalescedPreader cp;
+	CoalescedPreader cp = {0};
 
 	fd = open(fileName, O_RDONLY);
 	if (fd == -1) {


### PR DESCRIPTION
Fix this warning:
```
# make                                                                                                                                                      
for x in vmdk ova; do make -C $x all; done
make[1]: Entering directory '/workdir/open-vmdk-master/vmdk'
mkdir -p ../build/vmdk
gcc -W -Wall -O2 -g -c -o ../build/vmdk/flat.o flat.c
gcc -W -Wall -O2 -g -c -o ../build/vmdk/sparse.o sparse.c
sparse.c: In function 'Sparse_Open':
sparse.c:725:35: warning: 'cp.buf' may be used uninitialized in this function [-Wmaybe-uninitialized]
  725 |                     buf == p->buf + p->len) {
      |                            ~~~~~~~^~~~~~~~
sparse.c:911:19: note: 'cp.buf' was declared here
  911 |  CoalescedPreader cp;
      |                   ^~
sparse.c:724:13: warning: 'cp.pos' may be used uninitialized in this function [-Wmaybe-uninitialized]
  724 |   if (0 == p->pos + p->len - pos &&
      |            ~^~~~~
sparse.c:911:19: note: 'cp.pos' was declared here
  911 |  CoalescedPreader cp;
      |                   ^~
```