### PR TITLE
create $(DESTDIR)/etc/ if it does not exist

### DIFF
--- a/ova/Makefile
+++ b/ova/Makefile
@@ -21,5 +21,5 @@ all:
 
 install:
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin && cp $(EXE) $(DESTDIR)/$(PREFIX)/bin/
-	[ -f $(DESTDIR)/etc/open-vmdk.conf ] || echo "PREFIX=${PREFIX}" > $(DESTDIR)/etc/open-vmdk.conf
+	[ -f $(DESTDIR)/etc/open-vmdk.conf ] || mkdir -p $(DESTDIR)/etc/ && echo "PREFIX=${PREFIX}" > $(DESTDIR)/etc/open-vmdk.conf
 


### PR DESCRIPTION
Quick fix to create `$(DESTDIR)/etc/` if it doesn't exist.