### PR TITLE
fix vmdisk ids

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -532,7 +532,7 @@ class OVFDisk(object):
 
 
     def __init__(self, path):
-        self.id = f"vmdisk{OVFFile.next_id}"
+        self.id = f"vmdisk{OVFDisk.next_id}"
         OVFDisk.next_id += 1
         self.file = OVFFile(path)
 
@@ -558,7 +558,7 @@ class OVFDisk(object):
 
 class OVFEmptyDisk(OVFDisk):
     def __init__(self, capacity, units="MB"):
-        self.id = f"vmdisk{OVFFile.next_id}"
+        self.id = f"vmdisk{OVFDisk.next_id}"
         OVFDisk.next_id += 1
         self.capacity = capacity
         if units == "KB":


### PR DESCRIPTION
Before:

```xml
  <ovf:DiskSection>
    <ovf:Info>Virtual disk information</ovf:Info>
    <ovf:Disk ovf:capacity="7088373760" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk0" ovf:fileRef="file0" ovf:populatedSize="1963655168" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="51200" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="102400" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="204800" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
  </ovf:DiskSection>
```

After:

```xml
  <ovf:DiskSection>
    <ovf:Info>Virtual disk information</ovf:Info>
    <ovf:Disk ovf:capacity="7088373760" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk0" ovf:fileRef="file0" ovf:populatedSize="1963655168" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="51200" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="102400" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk2" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
    <ovf:Disk ovf:capacity="204800" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk3" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
  </ovf:DiskSection>
```