### PR TITLE
fix error when product section doesn't exist

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -953,7 +953,7 @@ class OVF(object):
         oss.append(xml_text_element('{%s}Info' % NS_OVF, "Operating System"))
         virtual_system.append(oss)
 
-        if self.product.transports:
+        if self.product and self.product.transports:
             transports = " ".join(self.product.transports)
             hw_attrs = {'{%s}transport' % NS_OVF: transports}
         else:


### PR DESCRIPTION
PR #27 introduced a bug. If the `product` section is not set, `ova-compose` will throw an error:
```
creating 'minimal-stig.ova' with format 'ova' from 'minimal.yaml'
Traceback (most recent call last):
  File "/usr/bin/ova-compose", line 1187, in <module>
    main()
  File "/usr/bin/ova-compose", line 1180, in main
    raise e
  File "/usr/bin/ova-compose", line 1156, in main
    ovf.write_xml(ovf_file=ovf_file)
  File "/usr/bin/ova-compose", line 993, in write_xml
    doc = self.to_xml()
          ^^^^^^^^^^^^^
  File "/usr/bin/ova-compose", line 956, in to_xml
    if self.product.transports:
       ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'transports'
```
Workaround is setting a `product` section, like this:
```
product:
    product: An Example VM
```