### PR TITLE
add 'no_default_configs' option to 'system'

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -825,7 +825,9 @@ class OVF(object):
                  vssd_system, rasd_items, extra_configs,
                  product, annotation, eula,
                  configurations):
-        self.hardware_config = OVF.CONFIG_DEFAULTS.copy()
+        self.hardware_config = {}
+        if not system.get('no_default_configs', False):
+            self.hardware_config.update(OVF.CONFIG_DEFAULTS)
         self.name = system['name']
         self.os_cim = system.get('os_cim', 100)
         self.os_vmw = system.get('os_vmw', "other4xLinux64Guest")


### PR DESCRIPTION
By default, `ova-compose` adds a list of `Config` items to the `VirtualHardwareSection`. This maybe not always desired. This change adds an option`no_default_configs` to `system` to skip the default config items. Example:
```
system:
    name: minimal
    type: vmx-14 vmx-20
...
    no_default_configs: True
```
