### PR TITLE
Honor compiler/linker flags from the environment

### DIFF
--- a/vmdk/Makefile
+++ b/vmdk/Makefile
@@ -20,8 +20,8 @@ EXE := $(OUTPUTDIR)/vmdk-convert
 PREFIX ?= /usr
 
 CC := gcc
-CFLAGS := -W -Wall -O2 -g
-LDFLAGS := -g -lz
+CFLAGS := -W -Wall -O2 -g $(CFLAGS)
+LDFLAGS := -g -lz $(LDFLAGS)
 
 OBJS := $(addprefix $(OUTPUTDIR)/, $(SRC:%.c=%.o))
 


### PR DESCRIPTION
Linux distributions set a bunch of flags during build among them are CFLAGS and LDFLAGS. Honor these so that we can build with the requested flags on these systems.