### PR TITLE
set default checksum type to sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ Options:
   * `ovf` to create just the OVF file
   * `dir` to create a directory containing the OVF file, the manifest and the files used for the cdrom and harddisk devices.
 * `--param <key=value>`: set parameter `<key>` to `<value>`.
- 
+* `--param <key=value>`: set parameter `<key>` to `<value>`
+* `--checksum-type sha256|sha512`: the checksum type used for the manifest file. The default is `sha256`.
+
 Example:
 ```
 $ ova-compose.py -i minimal.yaml -o minimal.ova

--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -1147,7 +1147,7 @@ def main():
     do_quiet = False
     do_manifest = False
     params = {}
-    checksum_type = "sha512"
+    checksum_type = "sha256"
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type='])

--- a/pytest/test_manifest.py
+++ b/pytest/test_manifest.py
@@ -72,7 +72,7 @@ def test_ovf_manifest(hash_type):
     if hash_type is not None:
         args += ["--checksum-type", hash_type]
     else:
-        hash_type = "sha512"
+        hash_type = "sha256"
 
     process = subprocess.run(args, cwd=WORK_DIR)
     assert process.returncode == 0
@@ -93,7 +93,7 @@ def test_ova_manifest(hash_type):
     if hash_type is not None:
         args += ["--checksum-type", hash_type]
     else:
-        hash_type = "sha512"
+        hash_type = "sha256"
 
     process = subprocess.run(args, cwd=WORK_DIR)
     assert process.returncode == 0


### PR DESCRIPTION
Had an internal discussion where we established that the manifest checksum is not intended for security but just as a sanity check. Since `sha512` is not always supported, set the default to `sha256`.