### PR TITLE
add NVME and USB3 controllers

### DIFF
--- a/ova-compose/example.yaml
+++ b/ova-compose/example.yaml
@@ -1,9 +1,9 @@
 system:
     name: example
-    type: vmx-17
+    type: vmx-21
     os_vmw: !param os=other4xLinux64Guest
     firmware: !param firmware=efi
-    secure_boot: !param secure-boot=true
+    secure_boot: !param secure-boot=false
 
 networks:
     vm_network:
@@ -17,19 +17,19 @@ hardware:
         type: sata_controller
     scsi1:
         type: scsi_controller
+    nvme1:
+        type: nvme_controller
     cdrom1:
         type: cd_drive
         parent: sata1
-    floppy1:
-        type: floppy
-        image: floppy.img
-        connected: true
     rootdisk:
         type: hard_disk
-        parent: scsi1
+        parent: nvme1
         disk_image: !param rootdisk
-    usb1:
+    usb2:
         type: usb_controller
+    usb3:
+        type: usb3_controller
     ethernet1:
         type: ethernet
         subtype: VmxNet3
@@ -45,6 +45,3 @@ product:
 
 annotation:
     text: the password is top secret
-
-eula:
-    file: !param eulafile

--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -279,6 +279,18 @@ class RasdSataController(RasdController):
     def xml_item(self, required, element_name):
         item = super().xml_item(required, element_name)
         item.append(self.xml_element('ResourceSubType', 'vmware.sata.ahci'))
+
+        return item
+
+
+class RasdNvmeController(RasdController):
+    resource_type = 20
+    description = "NVME Controller"
+
+
+    def xml_item(self, required, element_name):
+        item = super().xml_item(required, element_name)
+        item.append(self.xml_element('ResourceSubType', 'vmware.nvme.controller'))
         
         return item
 
@@ -356,6 +368,17 @@ class RasdUsbController(RasdItem):
         item = super().xml_item(required, element_name)
         item.append(self.xml_element('ResourceSubType', 'vmware.usb.ehci'))
         item.append(xml_config('ehciEnabled', 'true'))
+        return item
+
+
+class RasdUsb3Controller(RasdItem):
+    resource_type = 23
+    description = "USB3 Controller"
+
+
+    def xml_item(self, required, element_name):
+        item = super().xml_item(required, element_name)
+        item.append(self.xml_element('ResourceSubType', 'vmware.usb.xhci'))
         return item
 
 

--- a/pytest/configs/nvme.yaml
+++ b/pytest/configs/nvme.yaml
@@ -1,0 +1,36 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmw.vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    nvme1:
+        type: nvme_controller
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: nvme1
+        disk_image: dummy.vmdk
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci

--- a/pytest/configs/usb3.yaml
+++ b/pytest/configs/usb3.yaml
@@ -1,0 +1,36 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmw.vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: sata1
+        disk_image: dummy.vmdk
+    usb2:
+        type: usb_controller
+    usb3:
+        type: usb3_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci


### PR DESCRIPTION
Examples:
```
    nvme1:
        type: nvme_controller
...
    usb2:
        type: usb_controller
    usb3:
        type: usb3_controller
```
The NVME controller can be referenced just like SCSI or SATA (or IDE):
```
    rootdisk:
        type: hard_disk
        parent: nvme1
        disk_image: !param rootdisk
```
