### PR TITLE
add support for ip_assignment_settings

### DIFF
--- a/pytest/configs/ip_assignment_settings.yaml
+++ b/pytest/configs/ip_assignment_settings.yaml
@@ -1,0 +1,34 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+ip_assignment_settings:
+    protocols: IPv4,IPv6
+    schemes: ovfenv,dhcp
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci

--- a/pytest/configs/ip_assignment_settings2.yaml
+++ b/pytest/configs/ip_assignment_settings2.yaml
@@ -1,0 +1,38 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+ip_assignment_settings:
+    protocols:
+        - IPv4
+        - IPv6
+    schemes:
+        - ovfenv
+        - dhcp
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci


### PR DESCRIPTION
This adds `ip_assignment_settings`. Examples:
```
ip_assignment_settings:
    protocols: IPv4,IPv6
    schemes: ovfenv,dhcp
```
or 
```
ip_assignment_settings:
    protocols:
        - IPv4
        - IPv6
    schemes:
        - ovfenv
        - dhcp
```
`schemes` is optional.