### PR TITLE
add support for multiple product sections

### DIFF
--- a/pytest/configs/product_sections.yaml
+++ b/pytest/configs/product_sections.yaml
@@ -1,0 +1,65 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: sata1
+        disk_image: dummy.vmdk
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci
+
+product_sections:
+    - product: An Example VM
+      class: foo
+      vendor: A Company Inc.
+      properties:
+          vmname:
+            type: string
+            value: "Awesome Appliance"  
+
+    - instance: bar
+      transports:
+        - iso
+        - com.vmware.guestInfo
+      categories:
+          some: Some Properties
+      properties:
+          prop.int:
+              user_configurable: true
+              type: uint16
+              value: '50000'
+              description: "an unsigned integer"
+              label: "integer"
+              category: some
+          prop.string:
+              user_configurable: true
+              type: string
+              value: 'a string'
+              description: "a string, yo"
+              label: "string"
+              category: some


### PR DESCRIPTION
OVFs can have multiple product sections, but so far we allowed only one.

Since OVF properties are under the product sections, these need now be nested in the yaml config as well. The old way of configuring the `product` with one `ProductSection` is still allowed, but cannot be mixed with multiple `product_sections`.

Also adding atttributes `class`, `instance` and `required` for each `ProductSection`.