### PR TITLE
add fuse utility

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -9,7 +9,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: install build deps
-              run: sudo apt-get -y install zlib1g-dev
+              run: sudo apt-get -y install zlib1g-dev libfuse3-dev fuse2fs
 
             - name: build
               working-directory: ${{ github.workspace }}
@@ -18,6 +18,14 @@ jobs:
             - name: install
               working-directory: ${{ github.workspace }}
               run: sudo make install
+
+            - name: build-fuse
+              working-directory: ${{ github.workspace }}
+              run: make fuse
+
+            - name: install-fuse
+              working-directory: ${{ github.workspace }}
+              run: sudo make install-fuse
 
             - name: set up python 3
               uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@
 
 DIRS := vmdk ova ova-compose ovfenv templates
 
-default:: all
+default: all
 
 install all:
 	for x in $(DIRS); do $(MAKE) -C $$x $@; done
+
+fuse install-fuse:
+	$(MAKE) -C vmdk $@
 
 clean:
 	rm -rf build

--- a/pytest/test_fuse.py
+++ b/pytest/test_fuse.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2024 Broadcom, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the “License”); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at:
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+import hashlib
+import os
+import pytest
+import shutil
+import subprocess
+import time
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
+VMDK_FUSE=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-fuse")
+if not os.path.exists(VMDK_FUSE):
+    # skip this if we haven't built vmdk-fuse
+    pytestmark = pytest.mark.skip
+
+WORK_DIR=os.path.join(os.getcwd(), "pytest-fuse")
+
+IMAGE_FILE="dummy.img"
+VMDK_FILE="dummy.vmdk"
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test():
+    image_file = os.path.join(WORK_DIR, IMAGE_FILE)
+    vmdk_file = VMDK_FILE
+
+    os.makedirs(WORK_DIR, exist_ok=True)
+
+    process = subprocess.run(["dd", "if=/dev/zero", f"of={image_file}", "bs=1024", "count=1024"], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    process = subprocess.run(["mke2fs", image_file], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    process = subprocess.run([VMDK_CONVERT, image_file, vmdk_file], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    yield
+    shutil.rmtree(WORK_DIR)
+
+
+def _get_hash(filename, blocksz=1024 * 1024):
+    hash_type = "sha256"
+    hash = hashlib.new(hash_type)
+    with open(filename, "rb") as f:
+        while True:
+            buf = f.read(blocksz)
+            if not buf:
+                break
+            hash.update(buf)
+    return hash.hexdigest()
+
+
+def test_mount():
+    image_file = os.path.join(WORK_DIR, IMAGE_FILE)
+    vmdk_file = VMDK_FILE
+
+    mounted_image_path = os.path.join(WORK_DIR, "mounted.img")
+
+    with open(mounted_image_path, "w") as f:
+        pass
+
+    hash_orig = _get_hash(image_file)
+
+    try:
+        process = subprocess.run([VMDK_FUSE, f"--file={vmdk_file}", mounted_image_path], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        hash_mounted = _get_hash(mounted_image_path)
+        assert hash_mounted == hash_orig
+
+    finally:
+        subprocess.run(["fusermount", "-u", mounted_image_path], cwd=WORK_DIR, check=True)
+        assert not os.path.ismount(mounted_image_path)
+
+
+def test_mount_ext2():
+    vmdk_file = VMDK_FILE
+
+    mounted_image_path = os.path.join(WORK_DIR, "mounted.img")
+    mount_dir_path = os.path.join(WORK_DIR, "mntdir")
+
+    with open(mounted_image_path, "w") as f:
+        pass
+
+    os.makedirs(mount_dir_path, exist_ok=True)
+
+    try:
+        process = subprocess.run([VMDK_FUSE, f"--file={vmdk_file}", mounted_image_path], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        process = subprocess.run(["fuse2fs", mounted_image_path, mount_dir_path])
+        assert process.returncode == 0
+    finally:
+        subprocess.run(["fusermount", "-u", mount_dir_path], cwd=WORK_DIR)
+        while os.path.ismount(mount_dir_path):
+            time.sleep(0.1)
+        # avoid device busy, which can happen even after checking if the unmount is complete (there should be a better way)
+        time.sleep(0.1)
+        subprocess.run(["fusermount", "-u", mounted_image_path], cwd=WORK_DIR)

--- a/vmdk/Makefile
+++ b/vmdk/Makefile
@@ -14,26 +14,39 @@
 # ================================================================================
 
 SRC := flat.c sparse.c mkdisk.c
+SRC_FUSE := sparse.c vmdk-fuse.c
+
 OUTPUTDIR := ../build/vmdk
 EXE := $(OUTPUTDIR)/vmdk-convert
+EXE_FUSE := $(OUTPUTDIR)/vmdk-fuse
 
 PREFIX ?= /usr
 
 CC := gcc
 CFLAGS := -W -Wall -O2 -g $(CFLAGS)
 LDFLAGS := -g -lz $(LDFLAGS)
+LDFLAGS_FUSE := $(LDFLAGS) $$(pkg-config fuse3 --libs)
 
 OBJS := $(addprefix $(OUTPUTDIR)/, $(SRC:%.c=%.o))
+OBJS_FUSE := $(addprefix $(OUTPUTDIR)/, $(SRC_FUSE:%.c=%.o))
 
 default: all
+
+fuse: all $(EXE_FUSE)
 
 all: $(EXE)
 
 $(EXE): $(OBJS) $(OUTPUTDIR)
 	$(CC) -o $@ $(OBJS) $(LDFLAGS)
 
+$(EXE_FUSE): $(OBJS_FUSE) $(OUTPUTDIR)
+	$(CC) -o $@ $(OBJS_FUSE) $(LDFLAGS_FUSE)
+
 $(OUTPUTDIR)/%.o: %.c | $(OUTPUTDIR)
 	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(OUTPUTDIR)/vmdk-fuse.o: vmdk-fuse.c | $(OUTPUTDIR)
+	$(CC) $(CFLAGS) $$(pkg-config fuse3 --cflags) -c -o $@ $<
 
 $(OUTPUTDIR):
 	mkdir -p $(OUTPUTDIR)
@@ -47,6 +60,9 @@ check:
 
 install:
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin && cp $(EXE) $(DESTDIR)/$(PREFIX)/bin/
+
+install-fuse:
+	mkdir -p $(DESTDIR)/$(PREFIX)/bin && cp $(EXE_FUSE) $(DESTDIR)/$(PREFIX)/bin/
 
 clean:
 	rm -rf $(OUTPUTDIR)

--- a/vmdk/vmdk-fuse.c
+++ b/vmdk/vmdk-fuse.c
@@ -1,0 +1,233 @@
+/*
+  FUSE: Filesystem in Userspace
+  Copyright (C) 2001-2007  Miklos Szeredi <miklos@szeredi.hu>
+  Copyright (C) 2014 Broadcom
+
+  This program can be distributed under the terms of the GNU GPLv2.
+  See the file COPYING.
+*/
+
+/** @file
+ *
+ * This "filesystem" provides only a single file. The mountpoint
+ * needs to be a file rather than a directory.
+ */
+
+
+#define FUSE_USE_VERSION 31
+
+#include <fuse.h>
+#include <fuse_lowlevel.h>
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+
+#include "diskinfo.h"
+
+char *toolsVersion = "2147483647";
+
+struct options {
+    char *vmdk_path;
+};
+
+#define OPTION(t, p) { t, offsetof(struct options, p), 1 }
+static const struct fuse_opt option_spec[] = {
+    OPTION("--file=%s", vmdk_path),
+    FUSE_OPT_END
+};
+
+struct vmdk_data {
+    struct options options;
+    off_t capacity;
+};
+
+static int vmdk_getattr(const char *path, struct stat *stbuf,
+                        struct fuse_file_info *fi)
+{
+    (void) fi;
+    struct stat st;
+    struct vmdk_data *data = (struct vmdk_data *)fuse_get_context()->private_data;
+    char *vmdk_path = data->options.vmdk_path;
+
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    stat(vmdk_path, &st);
+
+    stbuf->st_mode = st.st_mode;
+    stbuf->st_nlink = 1;
+    stbuf->st_uid = getuid();
+    stbuf->st_gid = getgid();
+    stbuf->st_size = data->capacity;
+    stbuf->st_blocks = 0;
+    stbuf->st_atime = st.st_atime;
+    stbuf->st_mtime = st.st_mtime;
+    stbuf->st_ctime = st.st_ctime;
+
+	return 0;
+}
+
+static int vmdk_truncate(const char *path, off_t size,
+                         struct fuse_file_info *fi)
+{
+    (void) size;
+    (void) fi;
+
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    return -EROFS;
+}
+
+static int vmdk_open(const char *path, struct fuse_file_info *fi)
+{
+    (void) fi;
+
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    struct vmdk_data *data = (struct vmdk_data *)fuse_get_context()->private_data;
+    DiskInfo *di = Sparse_Open(data->options.vmdk_path);
+    if (di == NULL) {
+        fprintf(stderr, "could not read %s\n", data->options.vmdk_path);
+        return -EIO;
+    }
+
+    fi->fh = (uint64_t)di;
+
+    return 0;
+}
+
+static int vmdk_release(const char *path, struct fuse_file_info *fi)
+{
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    DiskInfo *di = (DiskInfo *)(fi->fh);
+    if (di == NULL)
+        return -EIO;
+
+    di->vmt->close(di);
+
+    return 0;
+}
+
+static int vmdk_read(const char *path, char *buf, size_t size,
+                     off_t offset, struct fuse_file_info *fi)
+{
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    DiskInfo *di = (DiskInfo *)(fi->fh);
+    if (di == NULL)
+        return -EIO;
+
+    ssize_t ret;
+    if ((ret = di->vmt->pread(di, (void *)buf, size, offset)) < 0) {
+        fprintf(stderr, "pread failed: %d (%s)\n", errno, strerror(errno));
+        return -EIO;
+    }
+
+    return ret;
+}
+
+static int vmdk_write(const char *path, const char *buf, size_t size,
+                      off_t offset, struct fuse_file_info *fi)
+{
+    (void) buf;
+    (void) offset;
+    (void) fi;
+    (void) size;
+
+    if(strcmp(path, "/") != 0)
+        return -ENOENT;
+
+    return -EROFS;
+}
+
+static const struct fuse_operations vmdk_oper = {
+    .getattr	= vmdk_getattr,
+    .truncate	= vmdk_truncate,
+    .open		= vmdk_open,
+    .release    = vmdk_release,
+    .read		= vmdk_read,
+    .write		= vmdk_write,
+};
+
+int vmdk_init(struct vmdk_data *data)
+{
+    DiskInfo *di;
+
+    di = Sparse_Open(data->options.vmdk_path);
+    if (di == NULL) {
+        fprintf(stderr, "could not read %s\n", data->options.vmdk_path);
+        return 1;
+    }
+    data->capacity = di->vmt->getCapacity(di);
+    di->vmt->close(di);
+
+    return 0;
+}
+
+static
+int vmdk_opt_proc(void *data, const char *arg,
+                  int key, struct fuse_args *outargs)
+{
+    struct vmdk_data *vmdk_data = (struct vmdk_data *)data;
+
+    switch (key) {
+    case FUSE_OPT_KEY_NONOPT:
+        if (vmdk_data->options.vmdk_path == NULL) {
+            vmdk_data->options.vmdk_path = strdup(arg);
+            return 0;
+        }
+        return 1;
+    }
+    return 1;
+}
+
+int main(int argc, char *argv[])
+{
+    struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
+    struct stat stbuf;
+    struct vmdk_data data = {0};
+    int argc_saved;
+    char **argv_saved;
+
+    if (fuse_opt_parse(&args, &data, option_spec, vmdk_opt_proc) == -1)
+            return 1;
+
+    if (!data.options.vmdk_path) {
+        fprintf(stderr, "missing vmdk file parameter (file=)\n");
+        return 1;        
+    } else {
+        char *tmp = data.options.vmdk_path;
+        data.options.vmdk_path = realpath(data.options.vmdk_path, NULL);
+        free(tmp);
+    }
+
+    if (stat(data.options.vmdk_path, &stbuf) == -1) {
+        fprintf(stderr ,"failed to access vmdk file %s: %s\n",
+            data.options.vmdk_path, strerror(errno));
+        free(data.options.vmdk_path);
+        return 1;
+    }
+    if (!S_ISREG(stbuf.st_mode)) {
+        fprintf(stderr, "vmdk file %s is not a regular file\n", data.options.vmdk_path);
+        return 1;
+    }
+
+    argc_saved = args.argc;
+    argv_saved = args.argv;
+
+    if (vmdk_init(&data) != 0) {
+        return 1;
+    }
+
+    return fuse_main(argc_saved, argv_saved, &vmdk_oper, (void *)&data);
+}


### PR DESCRIPTION
This adds a utility to mount a vmdk file as a raw disk image in read-only mode. The raw disk image can then be used with `kpartx`, or `partfs` (see https://github.com/braincorp/partfs) to access partitions, which can then be mounted. Example:
```
$ touch vmdk
$ vmdk-fuse --file=$(pwd)/minimal.vmdk ./vmdk
before fuse_main
$ ls -l
total 456800
-rw-r--r-- 1 okurth okurth  467756544 Mar 23 17:35 minimal.vmdk
-rw-r--r-- 1 okurth okurth 8589934592 Mar 23 17:35 vmdk     
$ mkdir partfs
$ partfs -o dev=./vmdk ./partfs/
$ ls -l partfs/
total 0
-rw-r--r-- 1 okurth okurth   10485760 Mar 23 17:35 p1
-rw-r--r-- 1 okurth okurth 7586430464 Mar 23 17:35 p2
-rw-r--r-- 1 okurth okurth  134217728 Mar 23 17:35 p3
-rw-r--r-- 1 okurth okurth  428867584 Mar 23 17:35 p4
-rw-r--r-- 1 okurth okurth  428867584 Mar 23 17:35 p5
$ mkdir p2
$ fuse2fs ./partfs/p2 ./p2 -o fakeroot,ro
Mounting read-only.
$ ls p2
bin  boot  dev  etc  extra  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
$ 
```