### PR TITLE
add disk_id/file_id options for disk images

### DIFF
--- a/pytest/configs/custom_disk_id.yaml
+++ b/pytest/configs/custom_disk_id.yaml
@@ -1,0 +1,41 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmw.vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: sata1
+        disk_image: dummy.vmdk
+        disk_id: dummy
+        file_id: dummy_id
+    homedisk_tall:
+        type: hard_disk
+        parent: sata1
+        disk_capacity: 10000
+        disk_id: tall
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci

--- a/pytest/test_configs.py
+++ b/pytest/test_configs.py
@@ -27,7 +27,7 @@ VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
 
 CONFIG_DIR=os.path.join(THIS_DIR, "configs")
 
-WORK_DIR=os.path.join(os.getcwd(), "pytest-tmp")
+WORK_DIR=os.path.join(os.getcwd(), "pytest-configs")
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -42,7 +42,7 @@ def setup_test():
 
     yield
     shutil.rmtree(WORK_DIR)
-    
+
 
 @pytest.mark.parametrize("in_yaml", glob.glob(os.path.join(CONFIG_DIR, "*.yaml")))
 def test_configs(in_yaml):

--- a/pytest/test_manifest.py
+++ b/pytest/test_manifest.py
@@ -28,7 +28,7 @@ VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
 
 CONFIG_DIR=os.path.join(THIS_DIR, "configs")
 
-WORK_DIR=os.path.join(os.getcwd(), "pytest-tmp")
+WORK_DIR=os.path.join(os.getcwd(), "pytest-manifest")
 
 
 @pytest.fixture(scope='module', autouse=True)


### PR DESCRIPTION
By default, disks and files get their IDs automatically, using `diskn` or `filem` as their IDs, where `n` and `m` are consecutive numbers. Sometimes, any post processing expects certain IDs. This PR adds options to set custom ids for disks and files.

Example:
```
    rootdisk:
        type: hard_disk
        parent: sata1
        disk_image: dummy.vmdk
        disk_id: dummy
        file_id: dummy_id
```

`disk_id` and `file_id` are independent from each other, any one can be set, or both.
