### PR TITLE
ova-compose: add raw_image option for disks

### DIFF
--- a/pytest/configs/raw-image.yaml
+++ b/pytest/configs/raw-image.yaml
@@ -1,0 +1,34 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmw.vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: sata1
+        raw_image: dummy.img
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci


### PR DESCRIPTION
This adds the `raw_image` option to disks. Example:
```
hardware:
...
    rootdisk:
        type: hard_disk
        parent: sata1
        raw_image: dummy.img
```
If present, the image file will be converted from raw image format to vmdk format, which will be packaged into the OVA (if configured to create an OVA). If the option `disk_image` is set, the vmdk file will be named to that value, otherwise, the name will be the same but with any extension stripped and `.vmdk` appended.

In the above example, the `vmdk` file will be named `dummy.vmdk`.

If the vmdk file already exists and is newer than the raw image file it will not be recreated. This is to avoid unnecessary conversions since this is time-intensive. If the raw image file does not exist but the vmdk file does, the vmdk file will be used, with a warning.