### PR TITLE
ova-compose: fix slowness of hashsum generation

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -1160,10 +1160,14 @@ class OVF(object):
 
 
     @staticmethod
-    def _get_hash(filename, hash_type):
+    def _get_hash(filename, hash_type, blocksz=1024 * 1024):
         hash = hashlib.new(hash_type)
         with open(filename, "rb") as f:
-            hash.update(f.read())
+            while True:
+                buf = f.read(blocksz)
+                if not buf:
+                    break
+                hash.update(buf)
         return hash.hexdigest()
 
 


### PR DESCRIPTION
Previously manifest hashsum generation will read the entire image file to memory and feed the buffer to hashlib. This can cause the python process to use excessive amount of memory and slow down hashsum generation, especially when the images are large (several GBs in size). Now, we fix it by reading the image file block by block. The block size is by default 1MB.