### PR TITLE
fix `abspath()` in `OVFFile`

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -532,7 +532,7 @@ class OVFFile(object):
     next_id = 0
 
     def __init__(self, path, file_id=None):
-        self.path = os.path.basename(path)
+        self.path = os.path.abspath(path)
         if file_id is None:
             self.id = f"file{OVFFile.next_id}"
             OVFFile.next_id += 1

--- a/pytest/configs/basic_param.yaml
+++ b/pytest/configs/basic_param.yaml
@@ -1,0 +1,34 @@
+system:
+    name: minimal
+    type: vmx-14 vmx-20
+    os_vmw: vmw.vmwarePhoton64Guest
+
+networks:
+    vm_network:
+        name: "None"
+        description: "The None network"
+
+hardware:
+    cpus: 2
+    memory:
+        type: memory
+        size: 4096
+    sata1:
+        type: sata_controller
+    cdrom1:
+        type: cd_drive
+        parent: sata1
+    rootdisk:
+        type: hard_disk
+        parent: sata1
+        disk_image: !param rootdisk=dummy.vmdk
+    usb1:
+        type: usb_controller
+    ethernet1:
+        type: ethernet
+        subtype: VmxNet3
+        network: vm_network
+    videocard1:
+        type: video_card
+    vmci1:
+        type: vmci

--- a/pytest/test_subdir.py
+++ b/pytest/test_subdir.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 VMware, Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the “License”); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at:
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+import glob
+import os
+import pytest
+import shutil
+import subprocess
+import yaml
+import xmltodict
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+OVA_COMPOSE = os.path.join(THIS_DIR, "..", "ova-compose", "ova-compose.py")
+
+VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
+
+CONFIG_DIR=os.path.join(THIS_DIR, "configs")
+
+WORK_DIR=os.path.join(os.getcwd(), "pytest-configs")
+SUB_DIR=os.path.join(WORK_DIR, "subdir")
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test():
+    os.makedirs(WORK_DIR, exist_ok=True)
+    os.makedirs(SUB_DIR, exist_ok=True)
+
+    process = subprocess.run(["dd", "if=/dev/zero", "of=dummy.img", "bs=1024", "count=1024"], cwd=SUB_DIR)
+    assert process.returncode == 0
+
+    process = subprocess.run([VMDK_CONVERT, "dummy.img", "dummy.vmdk"], cwd=SUB_DIR)
+    assert process.returncode == 0
+
+    yield
+    shutil.rmtree(WORK_DIR)
+
+
+def test_subdir():
+    in_yaml = os.path.join(CONFIG_DIR, "basic_param.yaml")
+
+    basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
+    out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
+
+    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "--param", f"rootdisk={SUB_DIR}/dummy.vmdk"], cwd=WORK_DIR)
+    assert process.returncode == 0


### PR DESCRIPTION
A recent change (c60d3a326b520ded3fae6680c43f41c38838afba)  changed using `abspath()` to `basename()`, which leads to a regression where files (eg. disk images) in other directories were not found.