### PR TITLE
ova-compose: add option to set tar format (default: `gnu`)

### DIFF
--- a/ova-compose/example.yaml
+++ b/ova-compose/example.yaml
@@ -1,6 +1,6 @@
 system:
     name: example
-    type: vmx-21
+    type: vmx-20
     os_vmw: !param os=other4xLinux64Guest
     firmware: !param firmware=efi
     secure_boot: !param secure-boot=false

--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -1247,7 +1247,7 @@ def main():
     do_manifest = False
     params = {}
     checksum_type = "sha256"
-    tar_format = "ustar"
+    tar_format = "gnu"
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type=', 'tar-format='])

--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -1247,9 +1247,10 @@ def main():
     do_manifest = False
     params = {}
     checksum_type = "sha256"
+    tar_format = "ustar"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type='])
+        opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type=', 'tar-format='])
     except:
         print ("invalid option")
         sys.exit(2)
@@ -1268,6 +1269,8 @@ def main():
         elif o in ['--param']:
             k,v = a.split('=', maxsplit=1)
             params[k] = yaml.safe_load(v)
+        elif o in ['--tar-format']:
+            tar_format = a
         elif o in ['-q']:
             do_quiet = True
         elif o in ['-h']:
@@ -1336,7 +1339,7 @@ def main():
             ovf.write_manifest(ovf_file=ovf_file, mf_file=mf_file, hash_type=checksum_type)
 
             if output_format == "ova":
-                ret = subprocess.check_call(["tar", "--format=ustar", "-h",
+                ret = subprocess.check_call(["tar", f"--format={tar_format}", "-h",
                                              "--owner=0", "--group=0", "--mode=0644",
                                              "-cf",
                                              os.path.join(pwd, output_file)] + all_files)


### PR DESCRIPTION
The OVA specification (https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf line 485) states that the `ustar` format should be used to create the OVA tar file. However, this format has a limit of 8GB for file sizes. Backends are okay with the default (`gnu`) tar format which supports unlimited file sizes. Setting this as the default because it is the safest option. The `gnu` format, in addition to supporting files > 8G, adds two extensions for long filenames and link targets which can cause issues, but these are rarely used.

The `posix` (PAX) format also supports files > 8GB, but this is implemented differently, and not supported by vSphere. Moreover, `posix` adds an extension that may cause issues with some older versions of vSphere. Therefore, using `posix` is not recommended. Documentation for `tar` also states that this will be the future default, therefore this change sets `gnu` explicitly by default.

The `ustar` format works fine as long as files are smaller than 8GB.

In summary, this option should be rarely used, but is there as a safety switch to fall back to `ustar` if `gnu` does not work.

A valid format supported by the underlying `tar` executable needs to be used, `ova-compose` will not check for valid options, and the `tar` command will fail if an invalid format is set. See `tar --help` if in doubt about supported formats.