### PR TITLE
test_files: pass 'vmdk-convert' path to ova-compose.py 

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -28,6 +28,8 @@ import shutil
 
 APP_NAME = "ova-compose"
 
+VMDK_CONVERT = "vmdk-convert"
+
 NS_CIM = "http://schemas.dmtf.org/wbem/wscim/1/common"
 NS_OVF = "http://schemas.dmtf.org/ovf/envelope/1"
 NS_RASD = "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData"
@@ -597,7 +599,7 @@ class OVFDisk(object):
                 # check if the vmdk exists, and if it does if it's newer than the raw image
                 # if not, create vmdk from raw image
                 if not os.path.exists(path) or os.path.getctime(raw_image) > os.path.getctime(path):
-                    subprocess.check_call(['vmdk-convert', raw_image, path])
+                    subprocess.check_call([VMDK_CONVERT, raw_image, path])
             else:
                 print(f"warning: raw image file {raw_image} does not exist, using {path}")
 
@@ -1061,7 +1063,7 @@ class OVF(object):
 
     @staticmethod
     def _disk_info(filename):
-        out = subprocess.check_output(["vmdk-convert", "-i", filename]).decode("UTF-8")
+        out = subprocess.check_output([VMDK_CONVERT, "-i", filename]).decode("UTF-8")
         return json.loads(out)
 
 
@@ -1250,7 +1252,7 @@ def main():
     tar_format = "gnu"
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type=', 'tar-format='])
+        opts, args = getopt.getopt(sys.argv[1:], 'f:hi:mo:q', longopts=['format=', 'input-file=', 'manifest', 'output-file=', 'param=', 'checksum-type=', 'tar-format=', 'vmdk-convert='])
     except:
         print ("invalid option")
         sys.exit(2)
@@ -1271,6 +1273,9 @@ def main():
             params[k] = yaml.safe_load(v)
         elif o in ['--tar-format']:
             tar_format = a
+        elif o in ['--vmdk-convert']:
+            global VMDK_CONVERT
+            VMDK_CONVERT = a
         elif o in ['-q']:
             do_quiet = True
         elif o in ['-h']:

--- a/pytest/test_configs.py
+++ b/pytest/test_configs.py
@@ -66,7 +66,7 @@ def test_configs(in_yaml):
     basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
     out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
 
-    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf], cwd=WORK_DIR)
+    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "--vmdk-convert", VMDK_CONVERT], cwd=WORK_DIR)
     assert process.returncode == 0
 
     with open(in_yaml) as f:

--- a/pytest/test_manifest.py
+++ b/pytest/test_manifest.py
@@ -68,7 +68,7 @@ def test_ovf_manifest(hash_type):
     out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
     out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m"]
+    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--vmdk-convert", VMDK_CONVERT]
     if hash_type is not None:
         args += ["--checksum-type", hash_type]
     else:
@@ -89,7 +89,7 @@ def test_ova_manifest(hash_type):
     out_ova = os.path.join(WORK_DIR, f"{basename}.ova")
     out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ova]
+    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ova, "--vmdk-convert", VMDK_CONVERT]
     if hash_type is not None:
         args += ["--checksum-type", hash_type]
     else:
@@ -109,7 +109,7 @@ def test_manifest_invalid_checksum_type():
     out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
     out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--checksum-type", "foobar"]
+    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--checksum-type", "foobar", "--vmdk-convert", VMDK_CONVERT]
     process = subprocess.run(args, cwd=WORK_DIR)
     assert process.returncode != 0
 

--- a/pytest/test_options.py
+++ b/pytest/test_options.py
@@ -56,6 +56,7 @@ def test_disk_file_id():
                               "--param", f"rootdisk=dummy.vmdk",
                               "--param", f"disk_id={disk_id}",
                               "--param", f"file_id={file_id}",
+                              "--vmdk-convert", VMDK_CONVERT
                              ],
                              cwd=WORK_DIR)
     assert process.returncode == 0

--- a/pytest/test_subdir.py
+++ b/pytest/test_subdir.py
@@ -52,5 +52,5 @@ def test_subdir():
     basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
     out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
 
-    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "--param", f"rootdisk={SUB_DIR}/dummy.vmdk"], cwd=WORK_DIR)
+    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "--param", f"rootdisk={SUB_DIR}/dummy.vmdk", "--vmdk-convert", VMDK_CONVERT], cwd=WORK_DIR)
     assert process.returncode == 0


### PR DESCRIPTION
Currently ova-compose.py expect vmdk-covert binary to be present otherwise there is test failure.
We provide the option to pass the created vmdk-convert binary path to be passed to  ova-compose.py file while running test files so that we use same vmdk-convert (used in test files to create .vmdk image) is used every place else.