### PR TITLE
 pytests: Add conftest.py and other tests

### DIFF
--- a/pytest/configs/all.yaml
+++ b/pytest/configs/all.yaml
@@ -2,6 +2,7 @@ system:
     name: minimal
     type: vmx-14 vmx-20
     os_vmw: vmwarePhoton64Guest
+    firmware: efi
 
 networks:
     vm_network:
@@ -16,11 +17,15 @@ hardware:
     memory:
         type: memory
         size: 4096
+    scsi1:
+        type: scsi_controller
+        subtype: lsilogic
     sata1:
         type: sata_controller
     cdrom1:
         type: cd_drive
         parent: sata1
+        connected: true
     rootdisk:
         type: hard_disk
         parent: sata1
@@ -31,6 +36,7 @@ hardware:
         type: ethernet
         subtype: VmxNet3
         network: vm_network
+        connected: false
     ethernet2:
         type: ethernet
         subtype: VmxNet3
@@ -75,6 +81,17 @@ product_sections:
               label: "string"
               category: some
               password: true
+
+configurations:
+    tall:
+        label: Tall
+        description: too little for the money
+    grande:
+        label: Grande
+        description: just right
+    venti:
+        label: Venti
+        description: too much
 
 annotation:
     text: the password is top secret

--- a/pytest/configs/raw-image.yaml
+++ b/pytest/configs/raw-image.yaml
@@ -22,6 +22,7 @@ hardware:
         type: hard_disk
         parent: sata1
         raw_image: dummy.img
+        file_id: file1
     usb1:
         type: usb_controller
     ethernet1:

--- a/pytest/test_all_configs.py
+++ b/pytest/test_all_configs.py
@@ -11,169 +11,141 @@
 # conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
 # specific language governing permissions and limitations under the License.
 
-import glob
 import os
 import pytest
-import shutil
-import subprocess
-import yaml
-import xmltodict
+import test_envelope_configs
 
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-OVA_COMPOSE = os.path.join(THIS_DIR, "..", "ova-compose", "ova-compose.py")
-
-VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
-
 CONFIG_DIR=os.path.join(THIS_DIR, "configs")
 
-WORK_DIR=os.path.join(os.getcwd(), "pytest-configs")
+
+@pytest.mark.parametrize('get_configs', [os.path.join(CONFIG_DIR, "all.yaml")], indirect=True)
+class TestAllConfigs:
+    ''' Test configs under each section '''
+
+    @pytest.fixture(autouse=True)
+    def setup_class(self, setup_test, get_configs):
+        self.config, self.ovf = get_configs
 
 
-@pytest.fixture(scope='module', autouse=True)
-def setup_test():
-    os.makedirs(WORK_DIR, exist_ok=True)
-
-    process = subprocess.run(["dd", "if=/dev/zero", "of=dummy.img", "bs=1024", "count=1024"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    process = subprocess.run([VMDK_CONVERT, "dummy.img", "dummy.vmdk"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    yield
-    shutil.rmtree(WORK_DIR)
+    def assert_values(self, val1, val2):
+        if val1:
+            assert val1 == val2
 
 
-def yaml_param(loader, node):
-    params = loader.app_params
-    default = None
-    key = node.value
+    def test_product_sections_configs(self):
+        #ProductSection
 
-    assert type(key) is str, f"param name must be a string"
+        cfg_product_sections = self.config["product_sections"]
+        cfg_vmw_ovf = self.ovf['Envelope']['VirtualSystem']['ProductSection']
 
-    if '=' in key:
-        key, default = [t.strip() for t in key.split('=', maxsplit=1)]
-        default = yaml.safe_load(default)
-    value = params.get(key, default)
+        transports = []
+        key_dict_product = {'instance': '@ovf:instance', 'class': '@ovf:class', 'vendor': 'Vendor',
+                            'product': 'Product', 'info': 'Info', 'version': 'Version', 'full_version': 'FullVersion'}
 
-    assert value is not None, f"no param set for '{key}', and there is no default"
+        key_dict_properties = {'type': '@ovf:type', 'value': '@ovf:value', 'description': 'Description', 'label': 'Label'}
 
-    return value
+        for i, cfg_product_section in enumerate(cfg_product_sections):
+            for el1, el2 in key_dict_product.items():
+                self.assert_values(cfg_product_section.get(el1), cfg_vmw_ovf[i].get(el2))
 
+            if cfg_product_section.get('properties'):
+                properties = cfg_vmw_ovf[i]['Property'] if isinstance(cfg_vmw_ovf[i]['Property'], list) else [cfg_vmw_ovf[i]['Property']]
+                for key in cfg_product_sections[i]['properties']:
+                     j = 0
+                     for j in range(len(properties)):
+                         if key == properties[j]['@ovf:key']:
+                             break
+                     self.assert_values(key, properties[j]['@ovf:key'])
+                     for el1, el2 in key_dict_properties.items():
+                         self.assert_values(cfg_product_section['properties'][key].get(el1), properties[j].get(el2))
+                     self.assert_values(cfg_product_section['properties'][key].get('user_configurable'),  bool(properties[j].get('@ovf:userConfigurable')))
+                     self.assert_values(cfg_product_section['properties'][key].get('password'),  bool(properties[j].get('@ovf:password')))
 
-def assert_values(val1, val2):
-    if val1:
-        assert val1 == val2
+            if 'categories' in cfg_product_section:
+                self.assert_values(list(cfg_product_section['categories'].values()), list(cfg_vmw_ovf[i].get('Category')))
 
+            if 'transports' in cfg_product_section:
+                transports.extend(cfg_product_section['transports'])
 
-@pytest.fixture(scope='module')
-def get_configs(setup_test):
-    in_yaml =  os.path.join(CONFIG_DIR, "all.yaml")
-    basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
-    out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
-
-    process = subprocess.run([OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "--vmdk-convert", VMDK_CONVERT], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    with open(in_yaml) as f:
-        yaml_loader = yaml.SafeLoader
-        yaml_loader.app_params = {}
-        yaml.add_constructor("!param", yaml_param, Loader=yaml_loader)
-        config = yaml.load(f, Loader=yaml_loader)
-
-    with open(out_ovf) as f:
-        ovf = xmltodict.parse(f.read())
-
-    yield config, ovf
+        if transports:
+            self.assert_values(set(transports), set(self.ovf['Envelope']['VirtualSystem']['VirtualHardwareSection']['@ovf:transport'].split()))
 
 
-def test_product_sections_configs(get_configs):
-    #ProductSection
-    config, ovf = get_configs
+    def test_annotation_configs(self):
+        #Annotation Section
 
-    cfg_product_sections = config["product_sections"]
-    cfg_vmw_ovf = ovf['Envelope']['VirtualSystem']['ProductSection']
+        cfg_annotation_section = self.config['annotation']
+        cfg_vmw_ovf =  self.ovf['Envelope']['VirtualSystem']['AnnotationSection']
 
-    transports = []
-    key_dict_product = {'instance': '@ovf:instance', 'class': '@ovf:class', 'vendor': 'Vendor',
-                        'product': 'Product', 'info': 'Info', 'version': 'Version', 'full_version': 'FullVersion'}
-
-    key_dict_properties = {'type': '@ovf:type', 'value': '@ovf:value', 'description': 'Description', 'label': 'Label'}
-
-    for i, cfg_product_section in enumerate(cfg_product_sections):
-        for el1, el2 in key_dict_product.items():
-            assert_values(cfg_product_section.get(el1), cfg_vmw_ovf[i].get(el2))
-
-        if cfg_product_section.get('properties'):
-            properties = cfg_vmw_ovf[i]['Property'] if isinstance(cfg_vmw_ovf[i]['Property'], list) else [cfg_vmw_ovf[i]['Property']]
-            for key in cfg_product_sections[i]['properties']:
-                 j = 0
-                 for j in range(len(properties)):
-                     if key == properties[j]['@ovf:key']:
-                         break
-                 assert_values(key, properties[j]['@ovf:key'])
-                 for el1, el2 in key_dict_properties.items():
-                     assert_values(cfg_product_section['properties'][key].get(el1), properties[j].get(el2))
-                 assert_values(cfg_product_section['properties'][key].get('user_configurable'),  bool(properties[j].get('@ovf:userConfigurable')))
-                 assert_values(cfg_product_section['properties'][key].get('password'),  bool(properties[j].get('@ovf:password')))
-
-        if 'categories' in cfg_product_section:
-            assert_values(list(cfg_product_section['categories'].values()), list(cfg_vmw_ovf[i].get('Category')))
-
-        if 'transports' in cfg_product_section:
-            transports.extend(cfg_product_section['transports'])
-
-    if transports:
-        assert_values(set(transports), set(ovf['Envelope']['VirtualSystem']['VirtualHardwareSection']['@ovf:transport'].split()))
+        if cfg_annotation_section.get('file'):
+            with open(cfg_annotation_section['file'], 'r') as f:
+                self.assert_values(f.read()[:-1], cfg_vmw_ovf.get('Annotation'))
+        else:
+            self.assert_values(cfg_annotation_section.get('text'), cfg_vmw_ovf.get('Annotation'))
+        self.assert_values(cfg_annotation_section.get('info'), cfg_vmw_ovf.get('Info'))
 
 
-def test_annotation_configs(get_configs):
-    #Annotation Section
-    config, ovf = get_configs
+    def test_networks_configs(self):
+        #Network Section
 
-    cfg_annotation_section = config['annotation']
-    cfg_vmw_ovf =  ovf['Envelope']['VirtualSystem']['AnnotationSection']
+        cfg_networks_section = self.config['networks']
+        cfg_vmw_ovf = self.ovf['Envelope']['NetworkSection']['Network']
+        cfg_vmw_ovf = cfg_vmw_ovf if isinstance(cfg_vmw_ovf, list) else [cfg_vmw_ovf]
 
-    if cfg_annotation_section.get('file'):
-        with open(cfg_annotation_section['file'], 'r') as f:
-            assert_values(f.read()[:-1], cfg_vmw_ovf.get('Annotation'))
-    else:
-        assert_values(cfg_annotation_section.get('text'), cfg_vmw_ovf.get('Annotation'))
-    assert_values(cfg_annotation_section.get('info'), cfg_vmw_ovf.get('Info'))
+        for idx, key in enumerate(cfg_networks_section):
+            self.assert_values(cfg_networks_section[key]['name'], cfg_vmw_ovf[idx]['@ovf:name'])
+            self.assert_values(f"The {cfg_networks_section[key]['name']} Network", cfg_vmw_ovf[idx]['Description'])
 
 
-def test_networks_configs(get_configs):
-    #Network Section
-    config, ovf = get_configs
+    def test_envelope_configs(self):
+        #Envelope Section
 
-    cfg_networks_section = config['networks']
-    cfg_vmw_ovf = ovf['Envelope']['NetworkSection']['Network']
-    cfg_vmw_ovf = cfg_vmw_ovf if isinstance(ovf['Envelope']['NetworkSection']['Network'], list) else [ovf['Envelope']['NetworkSection']['Network']]
-
-    for idx, key in enumerate(cfg_networks_section):
-        assert_values(cfg_networks_section[key]['name'], cfg_vmw_ovf[idx]['@ovf:name'])
-        assert_values(f"The {cfg_networks_section[key]['name']} Network", cfg_vmw_ovf[idx]['Description'])
+        test_envelope_configs.test_envelope_configs(None, (self.config, self.ovf))
 
 
-def test_envelope_configs(get_configs):
-    #Envelope Section
-    config, ovf = get_configs
+    def test_system_configs(self):
+        # Operating System Section
 
-    cfg_hardware_section =  config['hardware']
-    cfg_vmw_ovf = ovf['Envelope']['References']['File']
-    cfg_vmw_ovf = cfg_vmw_ovf if isinstance(ovf['Envelope']['References']['File'], list) else [ovf['Envelope']['References']['File']]
+        cfg_system_section = self.config['system']
+        cfg_vmw_ovf =  self.ovf['Envelope']['VirtualSystem']
+        vmw_configs = cfg_vmw_ovf['VirtualHardwareSection']['vmw:Config']
 
-    j = 0
-    for key in cfg_hardware_section:
-        if isinstance(cfg_hardware_section[key], dict):
-            image_path = cfg_hardware_section[key].get('disk_image') or cfg_hardware_section[key].get('raw_image')
-            if image_path:
-                image_path = image_path if image_path.endswith('.vmdk') else os.path.splitext(image_path)[0] + '.vmdk'
-                assert_values(image_path, cfg_vmw_ovf[j]['@ovf:href'])
-                assert_values(cfg_hardware_section[key].get('file_id'), cfg_vmw_ovf[j]['@ovf:id'])
-                j += 1
+        self.assert_values(cfg_system_section['name'], cfg_vmw_ovf['Name'])
+        self.assert_values(cfg_system_section['type'], cfg_vmw_ovf['VirtualHardwareSection']['System']['vssd:VirtualSystemType'])
+        self.assert_values(cfg_system_section['os_vmw'], cfg_vmw_ovf['OperatingSystemSection']['@vmw:osType'])
+
+        for vmw_config in vmw_configs:
+            if vmw_config['@vmw:key'] == "firmware":
+                self.assert_values(cfg_system_section.get('firmware', "bios"), vmw_config['@vmw:value'])
 
 
-def test_virtual_hardware_configs():
-    # TODO
-    pass
+    def test_virtual_hardware_configs(self):
+        #Hardware Section
+
+        cfg_hardware_section = self.config['hardware']
+        cfg_vmw_ovf = self.ovf['Envelope']['VirtualSystem']['VirtualHardwareSection']['Item']
+
+        for idx, key in enumerate(cfg_hardware_section):
+            self.assert_values(key, cfg_vmw_ovf[idx]['rasd:ElementName'])
+            if key == 'cpus':
+                self.assert_values(cfg_hardware_section[key], int(cfg_vmw_ovf[idx]['rasd:VirtualQuantity']))
+            elif key == 'memory':
+                self.assert_values(cfg_hardware_section[key]['size'], int(cfg_vmw_ovf[idx]['rasd:VirtualQuantity']))
+            else:
+                self.assert_values(cfg_hardware_section[key].get('subtype'), cfg_vmw_ovf[idx].get('rasd:ResourceSubType'))
+                self.assert_values(cfg_hardware_section[key].get('connected'), bool(cfg_vmw_ovf[idx].get('rasd:AutomaticAllocation')))
+
+
+    def test_configuration_configs(self):
+        #Deployment Option Section
+
+        cfg_configuration_section = self.config['configurations']
+        cfg_vmw_ovf = self.ovf['Envelope']['DeploymentOptionSection']['Configuration']
+        cfg_vmw_ovf = cfg_vmw_ovf if isinstance(cfg_vmw_ovf, list) else [cfg_vmw_ovf]
+
+        for idx, key in enumerate(cfg_configuration_section):
+            self.assert_values(key, cfg_vmw_ovf[idx]['@ovf:id'])
+            self.assert_values(cfg_configuration_section[key]['label'], cfg_vmw_ovf[idx]['Label'])
+            self.assert_values(cfg_configuration_section[key]['description'], cfg_vmw_ovf[idx]['Description'])

--- a/pytest/test_envelope_configs.py
+++ b/pytest/test_envelope_configs.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Broadcom.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the “License”); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at:
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+import glob
+import os
+import pytest
+import shutil
+import subprocess
+import yaml
+import xmltodict
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_DIR = os.path.join(THIS_DIR, "configs")
+
+
+def assert_values(val1, val2):
+    if val1:
+        assert val1 == val2
+
+
+@pytest.mark.parametrize('get_configs', [os.path.join(CONFIG_DIR, "all.yaml")], indirect=True)
+def test_envelope_configs(setup_test, get_configs):
+    #Envelope Section
+
+    config, ovf = get_configs
+
+    cfg_hardware_section =  config['hardware']
+    cfg_vmw_ovf = ovf['Envelope']['References']['File']
+    cfg_vmw_ovf = cfg_vmw_ovf if isinstance(cfg_vmw_ovf, list) else [cfg_vmw_ovf]
+
+    j = 0
+    for key in cfg_hardware_section:
+        if isinstance(cfg_hardware_section[key], dict):
+            image_path = cfg_hardware_section[key].get('disk_image') or cfg_hardware_section[key].get('raw_image')
+            if image_path:
+                image_path = image_path if image_path.endswith('.vmdk') else os.path.splitext(image_path)[0] + '.vmdk'
+                assert_values(image_path, cfg_vmw_ovf[j]['@ovf:href'])
+                assert_values(cfg_hardware_section[key].get('file_id'), cfg_vmw_ovf[j]['@ovf:id'])
+                j += 1

--- a/pytest/test_manifest.py
+++ b/pytest/test_manifest.py
@@ -31,85 +31,78 @@ CONFIG_DIR=os.path.join(THIS_DIR, "configs")
 WORK_DIR=os.path.join(os.getcwd(), "pytest-manifest")
 
 
-@pytest.fixture(scope='module', autouse=True)
-def setup_test():
-    os.makedirs(WORK_DIR, exist_ok=True)
-
-    process = subprocess.run(["dd", "if=/dev/zero", "of=dummy.img", "bs=1024", "count=1024"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    process = subprocess.run([VMDK_CONVERT, "dummy.img", "dummy.vmdk"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    yield
-    shutil.rmtree(WORK_DIR)
-
-
-def check_mf(mf_path, hash_type, work_dir=WORK_DIR):
-    with open(mf_path, "rt") as f:
-        for line in f:
-            left, hash_mf = line.split("=")
-            hash_mf = hash_mf.strip()
-
-            assert left.startswith(hash_type.upper())
-
-            filename = left[len(hash_type):].strip("()")
-            hash = hashlib.new(hash_type)
-            with open(os.path.join(work_dir, filename), "rb") as f:
-                hash.update(f.read())
-
-            assert hash.hexdigest() == hash_mf
-
-
+@pytest.mark.parametrize("setup_test", [WORK_DIR], indirect=True)
 @pytest.mark.parametrize("hash_type", [None, "sha1", "sha256", "sha512"])
-def test_ovf_manifest(hash_type):
-    in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
-    basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
-    out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
-    out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
+class TestOVFManifest:
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--vmdk-convert", VMDK_CONVERT]
-    if hash_type is not None:
-        args += ["--checksum-type", hash_type]
-    else:
-        hash_type = "sha256"
-
-    process = subprocess.run(args, cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    assert os.path.isfile(out_mf)
-
-    check_mf(out_mf, hash_type)
+    @pytest.fixture(autouse=True)
+    def setup_class(self, setup_test, hash_type):
+        self.hash_type = hash_type
 
 
-@pytest.mark.parametrize("hash_type", [None, "sha1", "sha256", "sha512"])
-def test_ova_manifest(hash_type):
-    in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
-    basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
-    out_ova = os.path.join(WORK_DIR, f"{basename}.ova")
-    out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
+    def check_mf(self, mf_path, work_dir=WORK_DIR):
+        with open(mf_path, "rt") as f:
+            for line in f:
+                left, hash_mf = line.split("=")
+                hash_mf = hash_mf.strip()
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ova, "--vmdk-convert", VMDK_CONVERT]
-    if hash_type is not None:
-        args += ["--checksum-type", hash_type]
-    else:
-        hash_type = "sha256"
+                assert left.startswith(self.hash_type.upper())
 
-    process = subprocess.run(args, cwd=WORK_DIR)
-    assert process.returncode == 0
+                filename = left[len(self.hash_type):].strip("()")
+                hash = hashlib.new(self.hash_type)
+                with open(os.path.join(work_dir, filename), "rb") as f:
+                    hash.update(f.read())
 
-    subprocess.run(["tar", "xf", out_ova], cwd=WORK_DIR)
-
-    check_mf(out_mf, hash_type)
+                assert hash.hexdigest() == hash_mf
 
 
-def test_manifest_invalid_checksum_type():
-    in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
-    basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
-    out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
-    out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
+    def test_ovf_manifest(self):
+        in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
+        basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
+        out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
+        out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
 
-    args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--checksum-type", "foobar", "--vmdk-convert", VMDK_CONVERT]
-    process = subprocess.run(args, cwd=WORK_DIR)
-    assert process.returncode != 0
+        args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--vmdk-convert", VMDK_CONVERT]
+        if self.hash_type is not None:
+            args += ["--checksum-type", self.hash_type]
+        else:
+            self.hash_type = "sha256"
+
+        process = subprocess.run(args, cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        assert os.path.isfile(out_mf)
+
+        self.check_mf(out_mf)
+
+
+    def test_ova_manifest(self):
+        in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
+        basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
+        out_ova = os.path.join(WORK_DIR, f"{basename}.ova")
+        out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
+
+        args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ova, "--vmdk-convert", VMDK_CONVERT]
+        if self.hash_type is not None:
+            args += ["--checksum-type", self.hash_type]
+        else:
+            self.hash_type = "sha256"
+
+        process = subprocess.run(args, cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        subprocess.run(["tar", "xf", out_ova], cwd=WORK_DIR)
+
+        self.check_mf(out_mf)
+
+
+    def test_manifest_invalid_checksum_type(self):
+        in_yaml = os.path.join(CONFIG_DIR, "basic.yaml")
+        basename = os.path.basename(in_yaml.rsplit(".", 1)[0])
+        out_ovf = os.path.join(WORK_DIR, f"{basename}.ovf")
+        out_mf = os.path.join(WORK_DIR, f"{basename}.mf")
+
+        args = [OVA_COMPOSE, "-i", in_yaml, "-o", out_ovf, "-m", "--checksum-type", "foobar", "--vmdk-convert", VMDK_CONVERT]
+        process = subprocess.run(args, cwd=WORK_DIR)
+        assert process.returncode != 0
 

--- a/pytest/test_options.py
+++ b/pytest/test_options.py
@@ -30,21 +30,7 @@ CONFIG_DIR=os.path.join(THIS_DIR, "configs")
 WORK_DIR=os.path.join(os.getcwd(), "pytest-configs")
 
 
-@pytest.fixture(scope='module', autouse=True)
-def setup_test():
-    os.makedirs(WORK_DIR, exist_ok=True)
-
-    process = subprocess.run(["dd", "if=/dev/zero", "of=dummy.img", "bs=1024", "count=1024"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    process = subprocess.run([VMDK_CONVERT, "dummy.img", "dummy.vmdk"], cwd=WORK_DIR)
-    assert process.returncode == 0
-
-    yield
-    shutil.rmtree(WORK_DIR)
-
-
-def test_disk_file_id():
+def test_disk_file_id(setup_test):
     disk_id = "foo_id"
     file_id = "bar_id"
     in_yaml = os.path.join(CONFIG_DIR, "custom_disk_id.yaml")


### PR DESCRIPTION
conftest.py contain common fixtures to setup and teardown.
We use them wherever feasible

Added Configurations and Hardware section tests in tests_all_configs.
It tests the keys present under those section in our config file.

pytest/test_raw_image_option.py checks .img if provided instead
of vmdk should still work.
After that it matches values for the same in ovf and our yaml.