### PR TITLE
fix SparsePread() reading chunks smaller than grain size

### DIFF
--- a/vmdk/sparse.c
+++ b/vmdk/sparse.c
@@ -810,6 +810,8 @@ SparsePread(DiskInfo *self,
 			break;
 		}
 		readLen = grainSize - readSkip;
+		if (len < readLen)
+			readLen = len;
 
 		sect = __le32_to_cpu(sdi->gtInfo.gt[grainNr]);
 		if (sect == 0) {


### PR DESCRIPTION
When reading small chunks that do not reach the end of the grain, `SparsePread()` would fail.