### PR TITLE
vmdk-convert: multithreaded compression

### DIFF
--- a/pytest/test_vmdk.py
+++ b/pytest/test_vmdk.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2025 Broadcom.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the “License”); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at:
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an “AS IS” BASIS, without warranties or
+# conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+# specific language governing permissions and limitations under the License.
+
+
+import hashlib
+import os
+import pytest
+import shutil
+import subprocess
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_DIR=os.path.join(THIS_DIR, "configs")
+VMDK_CONVERT=os.path.join(THIS_DIR, "..", "build", "vmdk", "vmdk-convert")
+WORK_DIR=os.path.join(os.getcwd(), "pytest-vmdk")
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test():
+    os.makedirs(WORK_DIR, exist_ok=True)
+
+    # this creates a mixed random file, with uncompressable data, zeros (skipped in the sparse vmdk), and compressible text
+    cmd = "( for i in $(seq 1 10) ; do dd if=/dev/zero count=1024 bs=1024 ; dd if=/dev/random count=1024 bs=1024 ; base64 /dev/urandom | dd count=1024 bs=1024 ; done ) > random.img"
+    process = subprocess.run(
+            ["/bin/sh", "-c", cmd],
+            cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    yield
+#    shutil.rmtree(WORK_DIR)
+
+
+def get_hash(filename):
+    hash_type = "sha256"
+    blocksz = 1024 * 1024
+    hash = hashlib.new(hash_type)
+    with open(filename, "rb") as f:
+        while True:
+            buf = f.read(blocksz)
+            if not buf:
+                break
+            hash.update(buf)
+    return hash.hexdigest()
+
+
+def test_no_option(setup_test):
+    img_name = "random.img"
+    img_name_back = "random-back.img"
+    vmdk_name = "random.vmdk"
+
+    orig_hash = get_hash(os.path.join(WORK_DIR, img_name))
+
+    process = subprocess.run([VMDK_CONVERT, img_name, vmdk_name], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    process = subprocess.run([VMDK_CONVERT, vmdk_name, img_name_back], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    hash = get_hash(os.path.join(WORK_DIR, img_name_back))
+    assert hash == orig_hash, f"hash of {img_name_back} ({hash[0:8]}) does not match that of original {img_name} ({orig_hash[0:8]}) for n={n}"
+
+
+def test_num_threads(setup_test):
+    img_name = "random.img"
+    img_name_back = "random-back.img"
+    vmdk_name = "random.vmdk"
+
+    orig_hash = get_hash(os.path.join(WORK_DIR, img_name))
+
+    for n in range(1, 8):
+        process = subprocess.run([VMDK_CONVERT, "-n", str(n), img_name, vmdk_name], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        process = subprocess.run([VMDK_CONVERT, vmdk_name, img_name_back], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        hash = get_hash(os.path.join(WORK_DIR, img_name_back))
+        assert hash == orig_hash, f"hash of {img_name_back} ({hash}) does not match that of original {img_name} ({orig_hash}) for n={n}"
+
+
+def test_compression_levels(setup_test):
+    img_name = "random.img"
+    img_name_back = "random-back.img"
+    vmdk_name = "random.vmdk"
+
+    orig_hash = get_hash(os.path.join(WORK_DIR, img_name))
+
+    for n in range(1, 9):
+        process = subprocess.run([VMDK_CONVERT, "-c", str(n), img_name, vmdk_name], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        process = subprocess.run([VMDK_CONVERT, vmdk_name, img_name_back], cwd=WORK_DIR)
+        assert process.returncode == 0
+
+        hash = get_hash(os.path.join(WORK_DIR, img_name_back))
+        assert hash == orig_hash, f"hash of {img_name_back} ({hash}) does not match that of original {img_name} ({orig_hash}) for n={n}"
+
+
+def test_both(setup_test):
+    img_name = "random.img"
+    img_name_back = "random-back.img"
+    vmdk_name = "random.vmdk"
+
+    orig_hash = get_hash(os.path.join(WORK_DIR, img_name))
+
+    process = subprocess.run([VMDK_CONVERT, "-c", "6", "-n", "4", img_name, vmdk_name], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    process = subprocess.run([VMDK_CONVERT, vmdk_name, img_name_back], cwd=WORK_DIR)
+    assert process.returncode == 0
+
+    hash = get_hash(os.path.join(WORK_DIR, img_name_back))
+    assert hash == orig_hash, f"hash of {img_name_back} ({hash}) does not match that of original {img_name} ({orig_hash}) for n={n}"

--- a/vmdk/diskinfo.h
+++ b/vmdk/diskinfo.h
@@ -29,6 +29,7 @@ typedef struct {
     int (*nextData)(DiskInfo *self, off_t *pos, off_t *end);
     int (*close)(DiskInfo *self);
     int (*abort)(DiskInfo *self);
+    ssize_t (*copyDisk)(DiskInfo *self, DiskInfo *src, int numThreads);
 } DiskInfoVMT;
 
 struct DiskInfo {

--- a/vmdk/flat.c
+++ b/vmdk/flat.c
@@ -78,7 +78,7 @@ FlatClose(DiskInfo *self)
 
 static int
 FlatNextData(DiskInfo *self,
-         off_t *pos,
+             off_t *pos,
              off_t *end)
 {
     FlatDiskInfo *fdi = getFDI(self);

--- a/vmdk/mkdisk.c
+++ b/vmdk/mkdisk.c
@@ -252,13 +252,8 @@ main(int argc,
             if (tgt == NULL) {
                 fprintf(stderr, "Cannot open target disk %s: %s\n", filename, strerror(errno));
             } else {
-<<<<<<< HEAD
-                printf("Starting to convert %s to %s using compression level %d\n", src, filename, compressionLevel);
-                if (copyDisk(di, tgt)) {
-=======
                 printf("Starting to convert %s to %s using compression level %d and %d threads\n", src, filename, compressionLevel, numThreads);
                 if (copyDisk(di, tgt, numThreads)) {
->>>>>>> b955bfd (Add multithreaded compression.)
                     printf("Success\n");
                 } else {
                     fprintf(stderr, "Failure!\n");


### PR DESCRIPTION
Use multiple threads for compressing grains in the VMDK. The number of concurrent threads is configurable.

Test in a 4 CPU VM running on Fusion on a M1 MacBook. Total time is inversely proportional to the number of threads used until it reaches the number of CPUs. Further adding any threads does not yield more efficiency:
```
$ for c in $(seq 1 9) ; do time ./build/vmdk/vmdk-convert -n $c ./minimal.img minimal-n$c.vmdk ; done
Starting to convert ./minimal.img to minimal-n1.vmdk...
using copyDisk
Success

real	1m0.174s
user	0m57.956s
sys	0m1.758s
Starting to convert ./minimal.img to minimal-n2.vmdk...
using copyDisk
Success

real	0m31.252s
user	1m0.105s
sys	0m1.883s
Starting to convert ./minimal.img to minimal-n3.vmdk...
using copyDisk
Success

real	0m21.390s
user	1m0.868s
sys	0m2.242s
Starting to convert ./minimal.img to minimal-n4.vmdk...
using copyDisk
Success

real	0m16.330s
user	1m0.974s
sys	0m2.410s
Starting to convert ./minimal.img to minimal-n5.vmdk...
using copyDisk
Success

real	0m16.250s
user	1m0.782s
sys	0m2.384s
Starting to convert ./minimal.img to minimal-n6.vmdk...
using copyDisk
Success

real	0m16.251s
user	1m0.799s
sys	0m2.663s
```

When combining with a weaker compression level:
```
$ time ./build/vmdk/vmdk-convert -n 4 -c 6 ./minimal.img minimal-n4-c6.vmdk
Starting to convert ./minimal.img to minimal-n4-c6.vmdk...
using copyDisk
Success

real	0m4.974s
user	0m15.705s
sys	0m2.390s
```
Sizes do not differ as expected:
```
$ ls -l *.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:25 minimal-n1.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:26 minimal-n2.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:26 minimal-n3.vmdk
-rw-rw-r-- 1 okurth okurth 241150976 Apr 15 23:30 minimal-n4-c6.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:27 minimal-n4.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:27 minimal-n5.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:27 minimal-n6.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:27 minimal-n7.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:28 minimal-n8.vmdk
-rw-rw-r-- 1 okurth okurth 240178688 Apr 15 23:28 minimal-n9.vmdk
```

This is an older less efficient implementation:
```
$ for c in $(seq 1 9) ; do time ./build/vmdk/vmdk-convert -n $c ./minimal.img minimal-n$c.vmdk ; done
Starting to convert ./minimal.img to minimal-n1.vmdk...
using copyDisk
Success

real	1m4.182s
user	0m54.946s
sys	0m3.385s
Starting to convert ./minimal.img to minimal-n2.vmdk...
using copyDisk
Success

real	0m38.404s
user	0m54.986s
sys	0m2.512s
Starting to convert ./minimal.img to minimal-n3.vmdk...
using copyDisk
Success

real	0m36.072s
user	0m55.286s
sys	0m2.657s
Starting to convert ./minimal.img to minimal-n4.vmdk...
using copyDisk
Success

real	0m24.501s
user	0m56.052s
sys	0m2.627s
Starting to convert ./minimal.img to minimal-n5.vmdk...
using copyDisk
Success

real	0m24.562s
user	0m56.373s
sys	0m2.476s
Starting to convert ./minimal.img to minimal-n6.vmdk...
using copyDisk
Success

real	0m23.455s
user	0m56.464s
sys	0m2.543s
Starting to convert ./minimal.img to minimal-n7.vmdk...
using copyDisk
Success

real	0m22.346s
user	0m56.536s
sys	0m2.603s
Starting to convert ./minimal.img to minimal-n8.vmdk...
using copyDisk
Success

real	0m21.675s
user	0m56.588s
sys	0m2.553s
Starting to convert ./minimal.img to minimal-n9.vmdk...
using copyDisk
Success

real	0m21.489s
user	0m56.814s
sys	0m2.440s
```