### PR TITLE
make sure VirtualSCSI is camel case in OVF, and allow buslogic and ls…

### DIFF
--- a/ova-compose/ova-compose.py
+++ b/ova-compose/ova-compose.py
@@ -278,8 +278,12 @@ class RasdScsiController(RasdController):
         # TODO: maintain valid settings in a structure instead of code:
         if self.subtype is None:
             self.subtype = 'VirtualSCSI'
-        elif self.subtype.lower() in ['virtualscsi', 'lsilogic']:
-            self.subtype = subtype
+        elif self.subtype.lower() in ['buslogic', 'lsilogic', 'lsilogicas', 'virtualscsi']:
+            # all subtypes must be lower case except VirtualSCSI, but we accept any case
+            if subtype.lower() == "virtualscsi":
+                self.subtype = "VirtualSCSI"
+            else:
+                self.subtype = subtype.lower()
         else:
             raise Exception(f"invalid SCSI subtype '{self.subtype}'")
 

--- a/pytest/configs/all.yaml
+++ b/pytest/configs/all.yaml
@@ -22,6 +22,9 @@ hardware:
     scsi1:
         type: scsi_controller
         subtype: lsilogic
+    scsi2:
+        type: scsi_controller
+        subtype: virtualscsi
     sata1:
         type: sata_controller
     cdrom1:

--- a/pytest/test_all_configs.py
+++ b/pytest/test_all_configs.py
@@ -186,7 +186,10 @@ class TestAllConfigs:
                     else:
                         self.assert_values(hw_item_cfg['size'], int(hw_item_ovf['rasd:VirtualQuantity']))
                 else:
-                    self.assert_values(hw_item_cfg.get('subtype'), hw_item_ovf.get('rasd:ResourceSubType'))
+                    subtype = hw_item_cfg.get('subtype')
+                    if subtype is not None and subtype.lower() == "virtualscsi":
+                        subtype = "VirtualSCSI"
+                    self.assert_values(subtype, hw_item_ovf.get('rasd:ResourceSubType'))
                     self.assert_values(hw_item_cfg.get('connected'), hw_item_ovf.get('rasd:AutomaticAllocation'))
 
                 if isinstance(hw_item_cfg, dict) and hw_item_cfg.get('config') is not None:


### PR DESCRIPTION
Some backends require the SCSI subtype to be cased as "VirtualSCSI". "virtualscsi" is rejected.

Also adding "buslogic" and "lsilogicas" to valid subtypes.